### PR TITLE
fix: use json to create dom elements to inject run buttons

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -8,7 +8,7 @@ const config = {
       'description': 'Run code online from sites like Github, Gitlab and more',
       'author': 'Shatrughn Gupta',
       'homepage_url': 'https://runmycode.online',
-      'version': '1.5.3',
+      'version': '1.6.0',
       'icons': { '128': 'icon128.png' },
       'manifest_version': 2,
       'content_scripts': [

--- a/common-utils.js
+++ b/common-utils.js
@@ -38,8 +38,6 @@
 
   const $ = (s, elem = document) => elem.querySelector(s)
   const $$ = (s, elem = document) => elem.querySelectorAll(s)
-  // https://stackoverflow.com/a/25214113
-  const htmlFromString = htmlStr => document.createRange().createContextualFragment(htmlStr)
 
   const getPlatform = () => {
     const l = window.location.hostname + '/' + window.location.pathname.split('/')[1]
@@ -71,10 +69,43 @@
     }).join('\n')
   }
 
+  // Simple function to create DOM from JSON like args
+  // Args is an array of 3 items: [tagName, attributes, textContent|child]
+  // For simplicity, element can have either text or a single direct child
+  // Example:
+  // buildDomElement(
+  //   ['div', {'class': 'abc'},
+  //     ['p', {'id': 'show'},
+  //       'Hello'
+  //     ]
+  //   ]
+  // )
+  // Ref1: https://developer.mozilla.org/en-US/Add-ons/Overlay_Extensions/XUL_School/DOM_Building_and_HTML_Insertion
+  // Ref2: https://bumbu.github.io/a-safe-function-to-build-html-elements-without-using-innerhtml/
+  const buildDomElement = (args) => {
+    const tagName = args[0]
+    const attrs = args[1]
+    const textContent = typeof args[2] === 'string' ? args[2] : null
+    const child = Array.isArray(args[2]) ? args[2] : null
+    // Create element
+    const parentNode = document.createElement(tagName.toUpperCase())
+    // Set attributes
+    for (let attr in attrs) {
+      parentNode.setAttribute(attr, attrs[attr])
+    }
+    // Add text or DOM child
+    if (textContent) {
+      parentNode.appendChild(document.createTextNode(textContent))
+    } else if (child) {
+      parentNode.appendChild(buildDomElement(child))
+    }
+    return parentNode
+  }
+
   // export
   rmc.$ = $
   rmc.$$ = $$
-  rmc.htmlFromString = htmlFromString
+  rmc.buildDomElement = buildDomElement
   rmc.displayLangMap = displayLangMap
   rmc.getPlatform = getPlatform
   rmc.getFileNameFromElement = getFileNameFromElement

--- a/platforms/bitbucket.js
+++ b/platforms/bitbucket.js
@@ -4,7 +4,7 @@
   const rmc = window.runmycode
   const $ = rmc.$
   const $$ = rmc.$$
-  const htmlFromString = rmc.htmlFromString
+  const buildDomElement = rmc.buildDomElement
   const getLangFromFileName = rmc.getLangFromFileName
   const getCodeFromLines = rmc.getCodeFromLines
 
@@ -13,7 +13,16 @@
 
   const bitbucketInjectRunButton = (btnContainer, fileName) => {
     if ($('.runmycode-popup-runner', btnContainer)) return
-    btnContainer.insertBefore(htmlFromString(`<div class="aui-buttons"><button class="aui-button aui-button-primary runmycode-popup-runner" style="font-weight: normal;" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</button></div>`), btnContainer.firstChild)
+    btnContainer.insertBefore(
+      buildDomElement(
+        ['div', {'class': 'aui-buttons'},
+          ['button', {'class': 'aui-button aui-button-primary runmycode-popup-runner', 'style': 'font-weight: normal;', 'data-filename': fileName, 'data-lang': getLangFromFileName(fileName)},
+            'Run'
+          ]
+        ]
+      ),
+      btnContainer.firstChild
+    )
   }
 
   const bitbucketRemoveRunButton = (openRunnerBtn) => {
@@ -92,7 +101,13 @@
     runButtonContainer: '.bb-content-container-header-primary',
     injectRunButton: (btnContainer, fileName) => {
       if ($('.runmycode-popup-runner', btnContainer)) return
-      btnContainer.appendChild(htmlFromString(`<div class="bb-content-container-item aui-buttons"><button class="aui-button aui-button-primary runmycode-popup-runner" style="font-weight: normal;" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</button></div>`))
+      btnContainer.appendChild(buildDomElement(
+        ['div', {'class': 'bb-content-container-item aui-buttons'},
+          ['button', {'class': 'aui-button aui-button-primary runmycode-popup-runner', 'style': 'font-weight: normal;', 'data-filename': fileName, 'data-lang': getLangFromFileName(fileName)},
+            'Run'
+          ]
+        ])
+      )
     },
     removeRunButton: bitbucketRemoveRunButton,
     addFileWatcher: true,

--- a/platforms/github.js
+++ b/platforms/github.js
@@ -4,7 +4,7 @@
   const rmc = window.runmycode
   const $ = rmc.$
   const $$ = rmc.$$
-  const htmlFromString = rmc.htmlFromString
+  const buildDomElement = rmc.buildDomElement
   const getLangFromFileName = rmc.getLangFromFileName
   const getCodeFromLines = rmc.getCodeFromLines
   const body = document.body
@@ -14,7 +14,16 @@
 
   const githubInjectRunButton = (btnContainer, fileName) => {
     if ($('.runmycode-popup-runner', btnContainer)) return
-    btnContainer.insertBefore(htmlFromString(`<div class="BtnGroup"><a class="btn btn-sm BtnGroup-item btn-purple runmycode-popup-runner" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</a></div>`), btnContainer.firstChild)
+    btnContainer.insertBefore(
+      buildDomElement(
+        ['div', {'class': 'BtnGroup'},
+          ['a', {'class': 'btn btn-sm BtnGroup-item btn-purple runmycode-popup-runner', 'data-filename': fileName, 'data-lang': getLangFromFileName(fileName)},
+            'Run'
+          ]
+        ]
+      ),
+      btnContainer.firstChild
+    )
   }
 
   const githubRemoveRunButton = (openRunnerBtn) => {
@@ -55,7 +64,14 @@
 
   const gistInjectRunButton = (btnContainer, fileName) => {
     if ($('.runmycode-popup-runner', btnContainer)) return
-    btnContainer.insertBefore(htmlFromString(`<a class="btn btn-sm btn-purple runmycode-popup-runner" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</a>`), btnContainer.firstChild)
+    btnContainer.insertBefore(
+      buildDomElement(
+        ['a', {'class': 'btn btn-sm btn-purple runmycode-popup-runner', 'data-filename': fileName, 'data-lang': getLangFromFileName(fileName)},
+          'Run'
+        ]
+      ),
+      btnContainer.firstChild
+    )
   }
 
   const gistRemoveRunButton = (openRunnerBtn) => {

--- a/platforms/gitlab.js
+++ b/platforms/gitlab.js
@@ -4,7 +4,7 @@
   const rmc = window.runmycode
   const $ = rmc.$
   const $$ = rmc.$$
-  const htmlFromString = rmc.htmlFromString
+  const buildDomElement = rmc.buildDomElement
   const getLangFromFileName = rmc.getLangFromFileName
   const getCodeFromLines = rmc.getCodeFromLines
   const body = document.body
@@ -14,7 +14,16 @@
 
   const gitlabInjectRunButton = (btnContainer, fileName) => {
     if ($('.runmycode-popup-runner', btnContainer)) return
-    btnContainer.insertBefore(htmlFromString(`<div class="btn-group"><a class="btn btn-sm btn-warning runmycode-popup-runner" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</a></div>`), btnContainer.firstChild)
+    btnContainer.insertBefore(
+      buildDomElement(
+        ['div', {'class': 'btn-group'},
+          ['a', {'class': 'btn btn-warning runmycode-popup-runner', 'data-filename': fileName, 'data-lang': getLangFromFileName(fileName)},
+            'Run'
+          ]
+        ]
+      ),
+      btnContainer.firstChild
+    )
   }
 
   const gitlabRemoveRunButton = (openRunnerBtn) => {
@@ -75,10 +84,7 @@
     containerSelector: '.file-holder',
     fileNameSelector: '.file-title-name',
     runButtonContainer: '.file-actions',
-    injectRunButton: (btnContainer, fileName) => {
-      if ($('.runmycode-popup-runner', btnContainer)) return
-      btnContainer.insertBefore(htmlFromString(`<div class="btn-group"><a class="btn btn-sm btn-warning runmycode-popup-runner" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}">Run</a></div>`), btnContainer.firstChild)
-    },
+    injectRunButton: gitlabInjectRunButton,
     getCode: (codeContainer) => getCodeFromLines($('.blob-content code', codeContainer).children)
   }
   gitlabSnippets.pages.edit = {
@@ -91,7 +97,16 @@
       const fileNameInput = $('.snippet-file-name', btnContainer)
       // shorten input box to accommodate open runner button
       Object.assign(fileNameInput.style, {display: 'inline-block', width: '60%'})
-      btnContainer.appendChild(htmlFromString(`<input type="button" class="btn btn-warning runmycode-popup-runner" style="float: right; font-weight: bold;" data-filename="${fileName}" data-lang="${getLangFromFileName(fileName)}" value="Run">`))
+      btnContainer.appendChild(
+        buildDomElement(['input', {
+          'type': 'button',
+          'class': 'btn btn-warning runmycode-popup-runner',
+          'style': 'float: right; font-weight: bold;',
+          'value': 'Run',
+          'data-filename': fileName,
+          'data-lang': getLangFromFileName(fileName)
+        }])
+      )
     },
     removeRunButton: (openRunnerBtn) => { openRunnerBtn.outerHTML = '' },
     addFileWatcher: true,

--- a/platforms/gobyexample.js
+++ b/platforms/gobyexample.js
@@ -4,7 +4,7 @@
   const rmc = window.runmycode
   const $ = rmc.$
   const $$ = rmc.$$
-  const htmlFromString = rmc.htmlFromString
+  const buildDomElement = rmc.buildDomElement
   const getCodeFromLines = rmc.getCodeFromLines
 
   rmc.platforms.gobyexample = {} // platform name should match whatever is defined in locationMap in common-utils.js
@@ -27,8 +27,14 @@
       openRunnerBtn.dataset.filename = $('body>div.example').id + '.go'
       openRunnerBtn.dataset.lang = 'go'
       const origAnchor = openRunnerBtn.parentNode
-      const goPlayLink = htmlFromString(`<a style="float: right; line-height: 1; margin-left: 10px;" title="Run this code in Go Playground" href="${origAnchor.href}">#</a>`)
-      origAnchor.parentNode.insertBefore(goPlayLink, origAnchor)
+      origAnchor.parentNode.insertBefore(
+        buildDomElement(
+          ['a', {'style': 'float: right; line-height: 1; margin-left: 10px;', 'title': 'Run this code in Go Playground', 'href': origAnchor.href},
+            '#'
+          ]
+        ),
+        origAnchor
+      )
       origAnchor.href = '#'
     },
     getCode: (codeContainer) => getCodeFromLines($$('.code>.highlight>pre', codeContainer))

--- a/runmycode.js
+++ b/runmycode.js
@@ -4,7 +4,6 @@
   const rmc = window.runmycode
   const $ = rmc.$
   const $$ = rmc.$$
-  const htmlFromString = rmc.htmlFromString
   const displayLangMap = rmc.displayLangMap
   const getFileNameFromElement = rmc.getFileNameFromElement
   const getLangFromFileName = rmc.getLangFromFileName
@@ -118,9 +117,9 @@
     if ($('#runmycode-runner')) return // runner is already present
 
     const runnerWidth = 350
-    const runnerHTML = htmlFromString(`<style>
+    const runnerMarkup = `<style>
     #runmycode-runner {
-      width: ${runnerWidth}px;
+      width: 350px;
     }
     </style>
 
@@ -156,9 +155,9 @@
           </div>
         </div>
       </div>
-    </div>`)
+    </div>`
     // inject runner styles and markup
-    body.appendChild(runnerHTML)
+    body.insertAdjacentHTML('afterbegin', runnerMarkup)
 
     /* *** Start Movable popup https://gist.github.com/akirattii/9165836 ****/
     runner = $('#runmycode-runner')

--- a/runmycode.js
+++ b/runmycode.js
@@ -117,7 +117,7 @@
     if ($('#runmycode-runner')) return // runner is already present
 
     const runnerWidth = 350
-    const runnerMarkup = `<style>
+    const runnerHTML = `<style>
     #runmycode-runner {
       width: 350px;
     }
@@ -157,7 +157,7 @@
       </div>
     </div>`
     // inject runner styles and markup
-    body.insertAdjacentHTML('afterbegin', runnerMarkup)
+    body.insertAdjacentHTML('afterbegin', runnerHTML)
 
     /* *** Start Movable popup https://gist.github.com/akirattii/9165836 ****/
     runner = $('#runmycode-runner')


### PR DESCRIPTION
This would avoid DOM XSS attacks caused by unsafe `insertAdjacentHTML` and its cousins.

## NOTE
This is still using `insertAdjacentHTML` at one place (https://github.com/shatgupt/runmycode-ext/pull/6/files#diff-f5504d6f46d00e8a8cb1ae7932b0c727R160) to insert the runner panel (only once on page load). It might be inefficient but should be safe since the html string is a fully static one and has no variable included. And also since the html fragment is very big, it will be too cumbersome to create a json template for it.